### PR TITLE
Removed client side URL validation for profile picture field

### DIFF
--- a/app/views/people/edit.html.erb
+++ b/app/views/people/edit.html.erb
@@ -1,5 +1,5 @@
 <h1>Account Settings <%= "for #{@person.fullname}" if @person.id != @current_user.id %></h1>
-Note: You must enter in your current password to make any changes to your settings.
+<p>Note: You must enter in your current password to make any changes to your settings.</p>
 
 <%= form_for @person do |f| %>
   <% if @person.errors.any? %>
@@ -33,10 +33,7 @@ Note: You must enter in your current password to make any changes to your settin
   </div>  
   
   <h4>Change Password</h4>
-  <div class="field">
-    <%= label :password, :current, "Current Password" %>
-    <%= password_field :password, :current %>
-  </div>
+
   <div class="field">
     <%= label :password, :new, "New Password" %>
     <%= password_field :password, :new %>
@@ -69,6 +66,13 @@ Note: You must enter in your current password to make any changes to your settin
     <%= f.label :date_of_birth %>
     <%= f.date_select :date_of_birth, :start_year=>1950, :end_year => Time.now.year %>
   </div>
+
+  <h4>Password</h4>
+  <div class="field">
+    <%= label :password, :current, "Current Password" %>
+    <%= password_field :password, :current %>
+  </div>
+
   <div class="actions">
     <%= f.submit "Update" %>
   </div>


### PR DESCRIPTION
Redmine ticket: https://hkn.eecs.berkeley.edu/redmine/issues/553

I changed the field for pictures on user profiles from url_field to text_field. This is to fix the fact that url_field requires full URLs.

I did not write any validation in the model, although there was none to begin with anyhow.

Additionally moved the password field to the bottom of the form for greater visibility.
