### PR TITLE
Added check to make sure committees listed in candidate app are actual committees

### DIFF
--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -146,7 +146,14 @@ class CandidatesController < ApplicationController
       @current_user.suggestion = suggestion
     end
 
-    flash[:notice] = "Your application has been saved."
+    errors = @current_user.candidate.errors
+    if not errors.empty?
+      if errors.include?(:committee_preferences)
+        flash[:notice] = "Your application has invalid committees listed. Please notify compserv@hkn."
+      end
+    else
+      flash[:notice] = "Your application has been saved."
+    end
     redirect_to :back
   end
 

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -15,6 +15,7 @@ class Candidate < ActiveRecord::Base
   has_many :challenges
   
   validates :person, :presence => true
+  validate :committees_must_be_valid
 
   scope :current, lambda { where(["candidates.created_at > ?", Property.semester_start_time]) }
   scope :approved, lambda { includes(:person).where(:people => {:approved => true}) }
@@ -22,6 +23,16 @@ class Candidate < ActiveRecord::Base
   def self.committee_defaults
     defaults = ["Activities", "Bridge", "CompServ", "Service", "Indrel", "StudRel", "Tutoring"]
     return defaults
+  end
+
+  def committees_must_be_valid
+    defaults = Candidate.committee_defaults.collect {|c| c.downcase}
+    for comm in committee_preferences.split
+      if not defaults.include?(comm.downcase)
+        errors.add(:committee_preferences, "contains invalid committees")
+        return
+      end
+    end
   end
   
   def event_requirements


### PR DESCRIPTION
Addresses concern that you could modify the HTML of the candidate application form and submit, saving whatever arbitrary data you'd like in our database.
