### PR TITLE
Hide tutor boxes with CSS

### DIFF
--- a/app/assets/stylesheets/tutor.css.erb
+++ b/app/assets/stylesheets/tutor.css.erb
@@ -53,6 +53,7 @@ html .dept-heading { font-weight: bold; }
     padding: 5px;
     background: white;
     border: 1px #ccc solid;
+    display: none;
 }
   
 .person{


### PR DESCRIPTION
No functional changes, unless the JavaScript happens to be broken/not working for some reason, in which case the tutor boxes are hidden.

Here is what it looks like before the fix:
![Tutor boxes in IE7, before fix](https://f.cloud.github.com/assets/2086910/482277/a9217efc-b890-11e2-91c4-46d41604ea25.png)

This deals with the terribly important issue here, because everyone still uses Internet Explorer 7:
https://hkn.eecs.berkeley.edu/redmine/issues/398
