### PR TITLE
Added year to event pages

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -79,19 +79,15 @@ class Event < ActiveRecord::Base
   end
 
   def nice_time_range(year = false)
-    if not(year)
-      if start_time.to_date == end_time.to_date 
-        "#{start_time.strftime('%a %m/%d %I:%M%p')} - #{end_time.strftime('%I:%M%p')}"
-      else 
-        "#{start_time.strftime('%a %m/%d %I:%M%p')} - #{end_time.strftime('%a %m/%d %I:%M%p')}"
-      end
-    else 
-      if start_time.to_date == end_time.to_date 
-        "#{start_time.strftime('%a %m/%d/%y %I:%M%p')} - #{end_time.strftime('%I:%M%p')}"
-      else 
-        "#{start_time.strftime('%a %m/%d/%y %I:%M%p')} - #{end_time.strftime('%a %m/%d/%y %I:%M%p')}"
-      end
+    date_format = year ? '%a %m/%d/%y' : '%a %m/%d'
+    time_format = '%I:%M%p'
+    start_format = "#{date_format} #{time_format}"
+    if start_time.to_date == end_time.to_date
+      end_format = time_format
+    else
+      end_format = "#{date_format} #{time_format}"
     end
+    "#{start_time.strftime(start_format)} - #{end_time.strftime(end_format)}"
   end
 
   def can_view? user

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -34,7 +34,7 @@
 %table#event_info.infobox{:style => "width: auto; margin-right: 20px;"}
   %tr
     %th Date
-    %td= @event.nice_time_range :year => true
+    %td= @event.nice_time_range(true) # Enable year
   %tr
     %th Location
     %td= @event.location


### PR DESCRIPTION
Added optional year to nice_time_range method for events, which adds the year to the date format.

Not sure if this is actually wanted, since the information it adds is usually of limited use.

Addresses issue here:
https://hkn.eecs.berkeley.edu/redmine/issues/304
