### PR TITLE
Fix link to coursesurvey information for professors

### DIFF
--- a/app/views/static/coursesurveys_how_to.html.erb
+++ b/app/views/static/coursesurveys_how_to.html.erb
@@ -1,5 +1,5 @@
 <p>
-  Instructors: see <a href="info_profs.shtml">Information for professors and TAs</a>.
+  Instructors: see <%= link_to 'Information for professors and TAs', coursesurveys_info_profs_path %>.
 </p>
 
 <h2>How We Evaluate Our Courses</h2>


### PR DESCRIPTION
Live link on [course surveys information page](https://hkn.eecs.berkeley.edu/coursesurveys/how-to) with text "Information for professors and TAs" is broken.
