### PR TITLE
fixes adblock on tutoring slots

### DIFF
--- a/app/controllers/admin/tutor_controller.rb
+++ b/app/controllers/admin/tutor_controller.rb
@@ -45,7 +45,7 @@ class Admin::TutorController < Admin::AdminController
         return
       end
     
-      tutor.adjacency = params[:adjacency]
+      tutor.adjacency = params[:adjacent_slots]
       tutor.save!
 
       params[:availabilities].each do |wday, hours|

--- a/app/views/admin/tutor/signup_slots.html.erb
+++ b/app/views/admin/tutor/signup_slots.html.erb
@@ -52,8 +52,8 @@ Note that there are five levels of preference, which roughly translate to "stron
 <p>Finally, you can also indicate your preference of adjacent time slots below.</p><br />
 
 <%= form_tag admin_tutor_update_slots_path, :method => :post do %>
-  <%= label_tag :adjacency, "Adjacent slots?" %>
-  <%= select_tag :adjacency, options_for_select([["Don't care", 0], ["Yes", 1], ["No", -1]], @adjacency) %>
+  <%= label_tag :adjacenct_slots, "Adjacent slots?" %>
+  <%= select_tag :adjacenct_slots, options_for_select([["Don't care", 0], ["Yes", 1], ["No", -1]], @adjacency) %>
   <br /><br />
 
   <div id="big-slider-container"><div id="big-slider"></div></div>


### PR DESCRIPTION
turns out adblock is preventing the adjacent slots? dialog from showing up on https://hkn.eecs.berkeley.edu/admin/tutor/signup_slots/
basically, because adjacency tags are blacklisted. worth fixing?
