### PR TITLE
Updated Gemfile for CAS/UCB_LDAP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'sunspot_solr'
 gem 'will_paginate', '~> 3.0'
 gem 'yaml_db'
 gem 'rubycas-client', :git => 'git://github.com/rubycas/rubycas-client.git'
-gem 'ucb_ldap'
+gem 'ucb_ldap', :git => 'https://github.com/compserv/ucb-ldap.git'
 
 group :development, :test do
   gem 'autotest-standalone'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,13 @@ GIT
       activesupport
 
 GIT
+  remote: https://github.com/compserv/ucb-ldap.git
+  revision: fd41e2774763ca184d199fb3f3ee89578a8673e4
+  specs:
+    ucb_ldap (2.0.0.pre6)
+      net-ldap (>= 0.6)
+
+GIT
   remote: https://github.com/stripe/stripe-ruby
   revision: da216fd53b7a5386c136e93bdfe5efaff20682b7
   specs:
@@ -148,7 +155,6 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    ruby-net-ldap (0.0.4)
     scrypt (1.2.1)
       ffi-compiler (>= 0.0.2)
       rake
@@ -181,8 +187,6 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.1.0)
       thread_safe (~> 0.1)
-    ucb_ldap (1.4.2)
-      ruby-net-ldap (>= 0.0.4)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.6)
@@ -222,7 +226,7 @@ DEPENDENCIES
   stripe!
   sunspot_rails
   sunspot_solr
-  ucb_ldap
+  ucb_ldap!
   webrat
   will_paginate (~> 3.0)
   yaml_db


### PR DESCRIPTION
Going to merge without review. I want to clean up the master branch on production because it has a revert and the repo doesn't, which...is less than desirable.

This will allow the use of the ucb_ldap gem without worrying about the ruby_net_ldap dependency.
