### PR TITLE
Added SLC 2015 link to navbar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,10 @@
   	    <% end %>
   	    <li><a class="navigation_toplevel_item" id="alumni" href="#">Alumni Network</a></li>
   	    <li><a class="navigation_toplevel_item" id="about" href="#">About HKN</a></li>
+        <li>
+          <a class="navigation_toplevel_item" id="slc" 
+              href="http://slc2015.hkn.mu/">SLC 2015</a>
+        </li>
   	    <% if @auth["candidates"] %>
   	      <li><a class="navigation_toplevel_item" id="cand" href="#">Candidate Portal</a></li>
   	    <% end %>


### PR DESCRIPTION
Someone used hard tabs in the other links and I didn't notice until this commit. Oh well. Here's a picture.

![image](https://cloud.githubusercontent.com/assets/2086910/6122906/ce23c214-b0af-11e4-956b-2651f23745fb.png)
