### PR TITLE
Disallow candidates from accessing Discourse SSO endpoint

### DIFF
--- a/app/controllers/discourse_sso_controller.rb
+++ b/app/controllers/discourse_sso_controller.rb
@@ -5,6 +5,12 @@ class DiscourseSsoController < ApplicationController
   before_filter :authorize, :only => [:sso]
 
   def sso
+    # Disallow candidates from registering/logging in
+    unless @current_user.in_group? "members"
+      redirect_to :root, :notice => "Only members can login to the forum."
+      return
+    end
+
     begin
       sso = SingleSignOn.parse(request.query_string, secret)
     rescue


### PR DESCRIPTION
Heh. Story time, I initially had this block below the SingleSignOn.parse check but I didn't want to set up on ghost to test with the Discourse instance, so I moved it to the top. Tested in the sense that I removed my "member" group and tried going to the endpoint and got booted back to home with the correct notice.

Side note: There should be a more uniform way of determining whether a Person has initiated. Upon promotion you're _supposed_ to have your candidates group removed, but a cursory inspection of the production candidates list contains current officers, so I decided to use membership in the "members" group to determine initiation status instead.
