### PR TITLE
Course survey name fixes

### DIFF
--- a/app/helpers/admin/csec_admin_helper.rb
+++ b/app/helpers/admin/csec_admin_helper.rb
@@ -27,7 +27,7 @@ module SurveyData
           end
         end
       rescue ParseError => e
-        results[:errors] = e.message + ["Example: #{INFO_EXAMPLE}"]
+        results[:errors] = [e.message, " Example: #{INFO_EXAMPLE}"]
         return results
       end
 
@@ -60,7 +60,7 @@ module SurveyData
           instructor = Instructor.new({title: 'ta', private: true, title: 'Teaching Assistant',
             last_name: last_name, first_name: first_name})
         else
-          raise ParseError, "Professor F:#{first_name}, L:#{last_name} does not exist in: #{survey_row}"
+          raise ParseError, "Professor /#{first_name}/#{last_name}/ does not exist in: #{survey_row}"
         end
       end
 
@@ -95,7 +95,7 @@ module SurveyData
         dept_id = dept.id
       end
 
-      log << "Parsed #{instructor.first_name} / #{instructor.last_name} teaching " +
+      log << "Parsed /#{instructor.first_name}/#{instructor.last_name}/ teaching " +
              "section #{section} of #{course_number}."
 
       return semester, dept_id, course_number, section, instructor, survey_answers


### PR DESCRIPTION
This fixes a bug where instructors with spaces in their name (e.g. Hilfinger,Paul N.) would not be parsed correctly. AFAICT, we've had this bug forever; I'm not sure how it didn't break horribly in previous semesters.

It also updates the error message to provide an example of a correct input, as well as modifying the error/log output slightly to more clearly demarcate first and last names. Tested on Ghost, seems to work.
