### PR TITLE
Use more human-friendly strftime in subject when replying to dept tours.

### DIFF
--- a/app/mailers/dept_tour_mailer.rb
+++ b/app/mailers/dept_tour_mailer.rb
@@ -12,7 +12,7 @@ class DeptTourMailer < ActionMailer::Base
   
   def dept_tour_response_email(dept_tour_request,resp_text,from,addtl_ccs)
     @resp_text = resp_text
-    mail :to => dept_tour_request.contact, :subject => "Department Tour Request on #{dept_tour_request.date}",
+    mail :to => dept_tour_request.contact, :subject => "Department Tour Request on #{dept_tour_request.date.strftime('%Y-%m-%d %I:%M %P')}",
       :from => from, :cc => [addtl_ccs, "deprel@hkn.eecs.berkeley.edu", from].reject{|eml| eml.blank?}.reduce { |eml,emls| eml + ', ' + emls }
   end
 end


### PR DESCRIPTION
This also makes it consistent with the time format in the original request that's emailed to deprel.
