### PR TITLE
Ignore case when finding instructors

### DIFF
--- a/app/helpers/admin/csec_admin_helper.rb
+++ b/app/helpers/admin/csec_admin_helper.rb
@@ -54,7 +54,7 @@ module SurveyData
       course_info.pop
       instructor_name = course_info.join(" ")
       last_name, first_name = instructor_name.split(',').collect(&:titleize_with_dashes)
-      instructor = Instructor.find_by(['last_name LIKE ? AND first_name LIKE ?', last_name, first_name])
+      instructor = Instructor.find_by(['UPPER(last_name) LIKE ? AND UPPER(first_name) LIKE ?', last_name.upcase, first_name.upcase])
       if instructor.nil? # We can create klasses/TAs, but creating professors leads to pain with typos
         if is_ta
           instructor = Instructor.new({title: 'ta', private: true, title: 'Teaching Assistant',


### PR DESCRIPTION
So that things won't break when a professor is named "John DeNero" in our database but our capitalization scheme enters it as "Denero".

Tested on Ghost, seems to work correctly.

If we ever get data with two distinct professors who only have different capitalizations of their name, we'll burn Soda Hall to the ground.
