### PR TITLE
Google Apps verification tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
   <%# Automatically includes javascript or css files with the same name as the controller %>
   <%= javascript_include_tag params[:controller] unless HknRails::Application.assets.find_asset("#{params[:controller]}.js").nil? %>
   <%= stylesheet_link_tag controller.controller_name if Rails.application.assets.find_asset("#{controller.controller_name}.css") %>
+  <meta name="google-site-verification" content="J_Vtxbv72xOD7F9XtcIhbAB3lcYexZ_jjg33Hvc3zxw" />
 </head>
 <body>
 <div id="bar">


### PR DESCRIPTION
This is just a tag that lets Google Apps know that we own the domain hkn.berkeley.edu, so that @hkn.berkeley.edu addresses work correctly.
