### PR TITLE
Fixed UnknownFormat exceptions in events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,6 +65,10 @@ class ApplicationController < ActionController::Base
       end
   end
 
+  def render_404
+    raise ActionController::RoutingError.new('Not Found')
+  end
+
   def test_exception_notification
     raise 'This is a test. This is only a test.'
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,8 @@
 class EventsController < ApplicationController
   before_filter :authorize_comms, :except => [:index, :calendar, :show, :hkn, :ical, :ical_single_event]
 
+  rescue_from ActionController::UnknownFormat, with: :render_404
+
   #[:index, :calendar, :show].each {|a| caches_action a, :layout => false}
 
   # GET /events

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>The page you wanted was not found (404)</title>
+  <link href="/stylesheets/error.css" rel="stylesheet" type="text/css" />
+</head>
+
+<body>
+  <div id="error">   
+  </div>
+</body>
+</html>


### PR DESCRIPTION
This will return 404 when googlebots try to access weird formats of our events page. I don't know how rails-y this actually is but i spent all of 161 lecture trying to find the best accepted practices for this :+1: 
