### PR TITLE
vp can see all rsvps

### DIFF
--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -72,10 +72,11 @@
     <h2>All RSVPs</h2>
     <ul>
     <% @person.rsvps.ordered_desc.each do |rsvp| %>
-	<li><%= link_to "#{rsvp.event.start_date} - #{rsvp.event.name}", rsvp.event %></li>
+      <li><%= link_to "#{rsvp.event.start_date} - #{rsvp.event.name}", rsvp.event %><% if rsvp.confirmed != 't' %> * <% end %></li>
     <% end %>
     </ul>
     <% end%>
+    * This event was not confirmed; either they didn't go, or VP forgot to confirm them.
 <% end %>
 </div>
 


### PR DESCRIPTION
VP can now see previous rsvps by going to a person's page. Currently only RSVPs from this semester are shown
