### PR TITLE
Add waitlisting to events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -147,17 +147,18 @@ class EventsController < ApplicationController
       @total_transportation = @event.rsvps.collect{|r| r.transportation || -1}.sum
       #@total_transportation = @event.rsvps.map{|rsvp| rsvp.transportation}.sum
     end
-    @rsvps = @event.rsvps.sort {|x,y| x.person.first_name <=> y.person.first_name }
+    # @rsvps = @event.rsvps.sort {|x,y| x.person.first_name <=> y.person.first_name }
     cap = @event.blocks.first.rsvp_cap
+    rsvps = @event.rsvps.order(:created_at)
     if cap.nil? or cap < 1
       # No cap
-      @admitted = @rsvps
-      @waitlist = []
+      admitted = rsvps
+      waitlist = []
     else
-      @rsvps = @rsvps.sort{ |a,b| a.created_at <=> b.created_at }
-      @admitted = @rsvps[0..cap-1]
-      @waitlist = @rsvps[cap..-1]
+      admitted = rsvps[0...cap]
+      waitlist = rsvps[cap..-1]
     end
+    @rsvp_lists = [["Admitted", admitted], ["Waitlist", waitlist]]
     @auth_event_owner = (@event.event_type.name == "Service" ? @auth['serv'] : @auth['act'])
     respond_to do |format|
       format.html # show.html.erb

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -154,8 +154,8 @@ class EventsController < ApplicationController
       @admitted = @rsvps
       @waitlist = []
     else
-      @rsvps = @rsvps.sort{|a,b| b.created_at <=> a.created_at}
-      @admitted = @rsvps[0..cap]
+      @rsvps = @rsvps.sort{ |a,b| a.created_at <=> b.created_at }
+      @admitted = @rsvps[0..cap-1]
       @waitlist = @rsvps[cap..-1]
     end
     @auth_event_owner = (@event.event_type.name == "Service" ? @auth['serv'] : @auth['act'])

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -148,7 +148,7 @@ class EventsController < ApplicationController
       #@total_transportation = @event.rsvps.map{|rsvp| rsvp.transportation}.sum
     end
     # @rsvps = @event.rsvps.sort {|x,y| x.person.first_name <=> y.person.first_name }
-    cap = @event.blocks.first.rsvp_cap
+    cap = @event.cap
     rsvps = @event.rsvps.order(:created_at)
     if cap.nil? or cap < 1
       # No cap

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -147,6 +147,17 @@ class EventsController < ApplicationController
       @total_transportation = @event.rsvps.collect{|r| r.transportation || -1}.sum
       #@total_transportation = @event.rsvps.map{|rsvp| rsvp.transportation}.sum
     end
+    @rsvps = @event.rsvps.sort {|x,y| x.person.first_name <=> y.person.first_name }
+    cap = @event.blocks.first.rsvp_cap
+    if cap.nil? or cap < 1
+      # No cap
+      @admitted = @rsvps
+      @waitlist = []
+    else
+      @rsvps = @rsvps.sort{|a,b| b.created_at <=> a.created_at}
+      @admitted = @rsvps[0..cap]
+      @waitlist = @rsvps[cap..-1]
+    end
     @auth_event_owner = (@event.event_type.name == "Service" ? @auth['serv'] : @auth['act'])
     respond_to do |format|
       format.html # show.html.erb

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -147,18 +147,7 @@ class EventsController < ApplicationController
       @total_transportation = @event.rsvps.collect{|r| r.transportation || -1}.sum
       #@total_transportation = @event.rsvps.map{|rsvp| rsvp.transportation}.sum
     end
-    # @rsvps = @event.rsvps.sort {|x,y| x.person.first_name <=> y.person.first_name }
-    cap = @event.cap
-    rsvps = @event.rsvps.order(:created_at)
-    if cap.nil? or cap < 1
-      # No cap
-      admitted = rsvps
-      waitlist = []
-    else
-      admitted = rsvps[0...cap]
-      waitlist = rsvps[cap..-1]
-    end
-    @rsvp_lists = [["Admitted", admitted], ["Waitlist", waitlist]]
+    @rsvp_lists = @event.rsvp_lists
     @auth_event_owner = (@event.event_type.name == "Service" ? @auth['serv'] : @auth['act'])
     respond_to do |format|
       format.html # show.html.erb

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -8,19 +8,7 @@ class RsvpsController < ApplicationController
   # GET /rsvps.xml
   def index
     # Most recently created RSVPs will show on top of the list
-    rsvps = @event.rsvps.order(:created_at)
-    cap = @event.cap
-    if cap.nil? or cap < 1
-      # No cap
-      admitted = rsvps
-      waitlist = []
-    else
-      admitted = rsvps[0...cap]
-      waitlist = rsvps[cap..-1]
-    end
-
-    @rsvp_lists = [["Admitted", admitted], ["Waitlist", waitlist]]
-
+    @rsvp_lists = @event.rsvp_lists
     respond_to do |format|
       format.html # index.html.erb
       format.xml  { render xml: rsvps }

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -68,8 +68,13 @@ class RsvpsController < ApplicationController
 
     respond_to do |format|
       if @rsvp.save
-        format.html { redirect_to(@event, notice: 'Thanks for RSVPing! See you there!') }
-        format.xml  { render xml: @rsvp, status: :created, location: @rsvp }
+        if @rsvp.waitlist_spot > 0
+          format.html { redirect_to(@event, notice: 'RSVP successful. You are on the waitlist, position #{@rsvp.waitlist_spot}') }
+          format.xml  { render xml: @rsvp, status: :created, location: @rsvp }
+        else
+          format.html { redirect_to(@event, notice: 'Thanks for RSVPing! See you there!') }
+          format.xml  { render xml: @rsvp, status: :created, location: @rsvp }
+        end
       else
         format.html { render action: "new" }
         format.xml  { render xml: @rsvp.errors, status: :unprocessable_entity }

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -73,21 +73,21 @@ class RsvpsController < ApplicationController
 
     assign_blocks
 
-    if @event.blocks.size == 1
-      block = @event.blocks.first
-      if block.full?
-        redirect_to @event, notice: 'Event is full.'
-        return
-      end
-    elsif @event.blocks.size > 1
-      @event.blocks.each do |block|
-        if block.full? and @rsvp.blocks.include? block
-          @rsvp.errors[:base] << "One or more RSVP blocks you selected is full."
-          render action: "new"
-          return
-        end
-      end
-    end
+    # if @event.blocks.size == 1
+    #   block = @event.blocks.first
+    #   if block.full?
+    #     redirect_to @event, notice: 'Event is full.'
+    #     return
+    #   end
+    # elsif @event.blocks.size > 1
+    #   @event.blocks.each do |block|
+    #     if block.full? and @rsvp.blocks.include? block
+    #       @rsvp.errors[:base] << "One or more RSVP blocks you selected is full."
+    #       render action: "new"
+    #       return
+    #     end
+    #   end
+    # end
 
     respond_to do |format|
       if @rsvp.save

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -177,16 +177,6 @@ class RsvpsController < ApplicationController
 
   def my_rsvps
     @rsvps = @current_user.rsvps
-    @waitlist_spots = @rsvps.map do |rsvp|
-      cap = rsvp.event.cap
-      if cap.nil? || cap < 1
-        0
-      else
-        [0, Rsvp.where(event_id: rsvp.event.id)
-                .where('created_at < ?', rsvp.created_at)
-                .count + 1 - cap].max
-      end
-    end
   end
 
 private

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -69,7 +69,7 @@ class RsvpsController < ApplicationController
     respond_to do |format|
       if @rsvp.save
         if @rsvp.waitlist_spot > 0
-          format.html { redirect_to(@event, notice: 'RSVP successful. You are on the waitlist, position #{@rsvp.waitlist_spot}') }
+          format.html { redirect_to(@event, notice: "RSVP successful. You are on the waitlist, position #{@rsvp.waitlist_spot}") }
           format.xml  { render xml: @rsvp, status: :created, location: @rsvp }
         else
           format.html { redirect_to(@event, notice: 'Thanks for RSVPing! See you there!') }

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -8,7 +8,18 @@ class RsvpsController < ApplicationController
   # GET /rsvps.xml
   def index
     # Most recently created RSVPs will show on top of the list
-    @rsvps = @event.rsvps.sort{|r1, r2| r2.created_at <=> r1.created_at }
+    rsvps = @event.rsvps.sort {|a, b| b.created_at <=> a.created_at }
+    cap = @event.blocks.first.rsvp_cap
+    if cap.nil? or cap < 1
+      # No cap
+      admitted = rsvps
+      waitlist = []
+    else
+      admitted = rsvps[0, cap]
+      waitlist = rsvps[cap, -1]
+    end
+
+    @rsvp_lists = [["Admitted", admitted], ["Waitlist", waitlist]]
 
     respond_to do |format|
       format.html # index.html.erb
@@ -30,13 +41,14 @@ class RsvpsController < ApplicationController
   # GET /rsvps/new
   # GET /rsvps/new.xml
   def new
-    if @event.blocks.size == 1
-      block = @event.blocks.first
-      if block.full?
-        redirect_to @event, notice: 'Event is full.'
-        return
-      end
-    end
+    # Allow all RSVPS, but waitlist
+    # if @event.blocks.size == 1
+      # block = @event.blocks.first
+      # if block.full?
+      #   redirect_to @event, notice: 'Event is full.'
+      #   return
+      # end
+    # end
     @rsvp = Rsvp.new
 
     respond_to do |format|

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -8,22 +8,22 @@ class RsvpsController < ApplicationController
   # GET /rsvps.xml
   def index
     # Most recently created RSVPs will show on top of the list
-    rsvps = @event.rsvps.sort {|a, b| a.created_at <=> b.created_at }
+    rsvps = @event.rsvps.order(:created_at)
     cap = @event.cap
     if cap.nil? or cap < 1
       # No cap
       admitted = rsvps
       waitlist = []
     else
-      admitted = rsvps[0, cap]
-      waitlist = rsvps[cap, -1]
+      admitted = rsvps[0...cap]
+      waitlist = rsvps[cap..-1]
     end
 
     @rsvp_lists = [["Admitted", admitted], ["Waitlist", waitlist]]
 
     respond_to do |format|
       format.html # index.html.erb
-      format.xml  { render xml: @rsvps }
+      format.xml  { render xml: rsvps }
     end
   end
 
@@ -42,13 +42,6 @@ class RsvpsController < ApplicationController
   # GET /rsvps/new.xml
   def new
     # Allow all RSVPS, but waitlist
-    # if @event.blocks.size == 1
-      # block = @event.blocks.first
-      # if block.full?
-      #   redirect_to @event, notice: 'Event is full.'
-      #   return
-      # end
-    # end
     @rsvp = Rsvp.new
 
     respond_to do |format|
@@ -72,22 +65,6 @@ class RsvpsController < ApplicationController
     @rsvp.confirmed = Rsvp::Unconfirmed
 
     assign_blocks
-
-    # if @event.blocks.size == 1
-    #   block = @event.blocks.first
-    #   if block.full?
-    #     redirect_to @event, notice: 'Event is full.'
-    #     return
-    #   end
-    # elsif @event.blocks.size > 1
-    #   @event.blocks.each do |block|
-    #     if block.full? and @rsvp.blocks.include? block
-    #       @rsvp.errors[:base] << "One or more RSVP blocks you selected is full."
-    #       render action: "new"
-    #       return
-    #     end
-    #   end
-    # end
 
     respond_to do |format|
       if @rsvp.save

--- a/app/controllers/rsvps_controller.rb
+++ b/app/controllers/rsvps_controller.rb
@@ -8,8 +8,8 @@ class RsvpsController < ApplicationController
   # GET /rsvps.xml
   def index
     # Most recently created RSVPs will show on top of the list
-    rsvps = @event.rsvps.sort {|a, b| b.created_at <=> a.created_at }
-    cap = @event.blocks.first.rsvp_cap
+    rsvps = @event.rsvps.sort {|a, b| a.created_at <=> b.created_at }
+    cap = @event.cap
     if cap.nil? or cap < 1
       # No cap
       admitted = rsvps
@@ -177,6 +177,16 @@ class RsvpsController < ApplicationController
 
   def my_rsvps
     @rsvps = @current_user.rsvps
+    @waitlist_spots = @rsvps.map do |rsvp|
+      cap = rsvp.event.cap
+      if cap.nil? || cap < 1
+        0
+      else
+        [0, Rsvp.where(event_id: rsvp.event.id)
+                .where('created_at < ?', rsvp.created_at)
+                .count + 1 - cap].max
+      end
+    end
   end
 
 private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -64,6 +64,20 @@ class Event < ActiveRecord::Base
     blocks.first.rsvp_cap
   end
 
+  def rsvp_lists
+    rsvps_by_time = self.rsvps.order(:created_at)
+    if cap.nil? or cap < 1
+      # No cap
+      admitted = rsvps_by_time
+      waitlist = []
+    else
+      admitted = rsvps_by_time[0...cap]
+      waitlist = rsvps_by_time[cap..-1]
+    end
+
+    [["Admitted", admitted], ["Waitlist", waitlist]]
+  end
+
   def valid_time_range
     if !start_time.blank? and !end_time.blank?
       errors[:end_time] << "must be after start time" unless start_time < end_time

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -60,6 +60,10 @@ class Event < ActiveRecord::Base
     end
   end
 
+  def cap
+    blocks.first.rsvp_cap
+  end
+
   def valid_time_range
     if !start_time.blank? and !end_time.blank?
       errors[:end_time] << "must be after start time" unless start_time < end_time

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -56,22 +56,22 @@ class Rsvp < ActiveRecord::Base
     event and event.need_transportation
   end
 
+  def waitlist_spot
+    if event.cap.nil? || event.cap < 1
+      -1
+    else
+      spot = Rsvp.where(event: event)
+                 .where('created_at < ?', created_at)
+                 .count - event.cap
+      [0, spot].max
+    end
+  end
+
   private
 
   def set_default_transportation
     if self.need_transportation
       self.transportation ||= TRANSPORT_ENUM.first.last
-    end
-  end
-
-  def waitlist_spot
-    cap = event.cap
-    if cap.nil? || cap < 1
-      -1
-    else
-      [0, Rsvp.where(event_id: rsvp.event.id)
-              .where('created_at < ?', rsvp.created_at)
-              .count + 1 - event.cap].max
     end
   end
 end

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -63,4 +63,15 @@ class Rsvp < ActiveRecord::Base
       self.transportation ||= TRANSPORT_ENUM.first.last
     end
   end
+
+  def waitlist_spot
+    cap = event.cap
+    if cap.nil? || cap < 1
+      0
+    else
+      [0, Rsvp.where(event_id: rsvp.event.id)
+              .where('created_at < ?', rsvp.created_at)
+              .count + 1 - event.cap].max
+    end
+  end
 end

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -67,7 +67,7 @@ class Rsvp < ActiveRecord::Base
   def waitlist_spot
     cap = event.cap
     if cap.nil? || cap < 1
-      0
+      -1
     else
       [0, Rsvp.where(event_id: rsvp.event.id)
               .where('created_at < ?', rsvp.created_at)

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -9,16 +9,26 @@
     - if @event.need_transportation
       %p
         Total Transportation: #{@total_transportation}
-    %p
-      - events = @event.rsvps.sort {|x,y| x.person.first_name <=> y.person.first_name }
-      - events.each do |rsvp|
+    %h2 Admitted
+    %ul
+      - @admitted.each do |rsvp|
         - person = rsvp.person
-        = link_to person.fullname, person
-        = " (#{person.email})" if @auth_event_owner
-        - if @event.need_transportation
-          (#{rsvp.transportation})
-        - if events.last != rsvp
-          ,
+        %li
+          = link_to person.fullname, person
+          = " (#{person.email})" if @auth_event_owner
+          - if @event.need_transportation
+            (#{rsvp.transportation})
+    - if not (@waitlist.nil? or @waitlist.empty?)
+      %h2 Waitlist
+      %ul
+        - @waitlist.each do |rsvp|
+          - person = rsvp.person
+          %li
+            = link_to person.fullname, person
+            = " (#{person.email})" if @auth_event_owner
+            - if @event.need_transportation
+              (#{rsvp.transportation})
+    %p
       - if @event.blocks.size > 1
         %h1 Time Slots
         - @event.blocks.each do |block|

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -78,10 +78,6 @@
       = link_to 'Remove My RSVP', event_rsvp_path(@event, @current_user_rsvp), confirm: 'Are you sure?', method: :delete
       |
     - elsif @event.can_rsvp? @current_user
-      - if ((@event.blocks.size == 1 and !@event.blocks.first.full?) or (@event.blocks.size > 1))
-        = link_to 'RSVP', '/events/' + @event.id.to_s + '/rsvps/new'
-        |
-      - else
-        %strong RSVPs FULL
-        |
+      = link_to 'RSVP', '/events/' + @event.id.to_s + '/rsvps/new'
+      |
   = link_to 'Back to Calendar', events_calendar_path(year: @event.start_time.year, month: @event.start_time.month)

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -9,25 +9,17 @@
     - if @event.need_transportation
       %p
         Total Transportation: #{@total_transportation}
-    %h2 Admitted (#{@admitted.count})
-    %ul
-      - @admitted.each do |rsvp|
-        - person = rsvp.person
-        %li
-          = link_to person.fullname, person
-          = " (#{person.email})" if @auth_event_owner
-          - if @event.need_transportation
-            (#{rsvp.transportation})
-    - if not (@waitlist.nil? or @waitlist.empty?)
-      %h2 Waitlist (#{@waitlist.count})
-      %ul
-        - @waitlist.each do |rsvp|
-          - person = rsvp.person
-          %li
-            = link_to person.fullname, person
-            = " (#{person.email})" if @auth_event_owner
-            - if @event.need_transportation
-              (#{rsvp.transportation})
+    - @rsvp_lists.each do |label, list|
+      - if not (list.nil? or list.empty?)
+        %h2 #{label} (#{list.count})
+        %ul
+          - list.each do |rsvp|
+            - person = rsvp.person
+            %li
+              = link_to person.fullname, person
+              = " (#{person.email})" if @auth_event_owner
+              - if @event.need_transportation
+                (#{rsvp.transportation})
     %p
       - if @event.blocks.size > 1
         %h1 Time Slots

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -9,7 +9,7 @@
     - if @event.need_transportation
       %p
         Total Transportation: #{@total_transportation}
-    %h2 Admitted
+    %h2 Admitted (#{@admitted.count})
     %ul
       - @admitted.each do |rsvp|
         - person = rsvp.person

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -19,7 +19,7 @@
           - if @event.need_transportation
             (#{rsvp.transportation})
     - if not (@waitlist.nil? or @waitlist.empty?)
-      %h2 Waitlist
+      %h2 Waitlist (#{@waitlist.count})
       %ul
         - @waitlist.each do |rsvp|
           - person = rsvp.person

--- a/app/views/rsvps/index.html.erb
+++ b/app/views/rsvps/index.html.erb
@@ -1,5 +1,7 @@
 <h1>Listing RSVPs for <%= @event.name %></h1>
 
+<% @rsvp_lists.each do |label, list| %>
+<h2><%= label %></h2>
 <table>
   <tr>
     <th>Person</th>
@@ -15,7 +17,7 @@
     <% end %>
   </tr>
 
-<% @rsvps.each do |rsvp| %>
+<% list.each do |rsvp| %>
   <tr>
     <td><%= rsvp.person.fullname %></td>
     <td><%= rsvp.comment if rsvp.comment.present? %></td>
@@ -33,5 +35,6 @@
 </table>
 
 <br />
+<% end %>
 
 <%= link_to 'New Rsvp', new_event_rsvp_path(@event) %>

--- a/app/views/rsvps/my_rsvps.html.erb
+++ b/app/views/rsvps/my_rsvps.html.erb
@@ -3,6 +3,7 @@
 <table>
   <tr>
     <th>Event</th>
+    <th>Waitlist spot</th>
     <th>Confirmed?</th>
     <th></th>
     <% if @auth['comms'] %>
@@ -11,9 +12,10 @@
     <% end %>
   </tr>
 
-<% @rsvps.each do |rsvp| %>
+<% @rsvps.zip(@waitlist_spots).each do |rsvp, waitlist| %>
   <tr>
     <td><%= rsvp.event.name %></td>
+    <td><%= waitlist == 0 ? "not on waitlist" : waitlist %></td>
     <td><%= rsvp.confirmed == 't' ? "Yes" : "No" %></td>
     <td><%= link_to 'Show', event_rsvp_path(rsvp.event, rsvp) %></td>
     <% if @auth['comms'] %>

--- a/app/views/rsvps/my_rsvps.html.erb
+++ b/app/views/rsvps/my_rsvps.html.erb
@@ -15,7 +15,13 @@
 <% @rsvps.each do |rsvp| %>
   <tr>
     <td><%= rsvp.event.name %></td>
-    <td><%= rsvp.waitlist_spot == 0 ? "not on waitlist" : rsvp.waitlist_spot %></td>
+    <td>
+      <% if rsvp.waitlist_spot == 0 %>
+        not on waitlist
+      <% elsif rsvp.waitlist_spot > 0 %>
+        <%= rsvp.waitlist_spot %>
+      <% end %>
+    </td>
     <td><%= rsvp.confirmed == 't' ? "Yes" : "No" %></td>
     <td><%= link_to 'Show', event_rsvp_path(rsvp.event, rsvp) %></td>
     <% if @auth['comms'] %>

--- a/app/views/rsvps/my_rsvps.html.erb
+++ b/app/views/rsvps/my_rsvps.html.erb
@@ -16,9 +16,7 @@
   <tr>
     <td><%= rsvp.event.name %></td>
     <td>
-      <% if rsvp.waitlist_spot == 0 %>
-        not on waitlist
-      <% elsif rsvp.waitlist_spot > 0 %>
+      <% if rsvp.waitlist_spot > 0 %>
         <%= rsvp.waitlist_spot %>
       <% end %>
     </td>

--- a/app/views/rsvps/my_rsvps.html.erb
+++ b/app/views/rsvps/my_rsvps.html.erb
@@ -12,10 +12,10 @@
     <% end %>
   </tr>
 
-<% @rsvps.zip(@waitlist_spots).each do |rsvp, waitlist| %>
+<% @rsvps.each do |rsvp| %>
   <tr>
     <td><%= rsvp.event.name %></td>
-    <td><%= waitlist == 0 ? "not on waitlist" : waitlist %></td>
+    <td><%= rsvp.waitlist_spot == 0 ? "not on waitlist" : rsvp.waitlist_spot %></td>
     <td><%= rsvp.confirmed == 't' ? "Yes" : "No" %></td>
     <td><%= link_to 'Show', event_rsvp_path(rsvp.event, rsvp) %></td>
     <% if @auth['comms'] %>


### PR DESCRIPTION
This pull request adds waitlisting to events.

It does not add any extra model fields to do so; waitlist numbers are determined by sorting by rsvp creation times `created_at`, and calculated at request time. Doing so has the advantage of not requiring any sql migrations and being automatically consistent without O(n) rsvp updates when removing rsvps.

Allowing people to rsvp beyond the cap is implemented by removing the capacity check when creating an rsvp object. (The rsvp cap is a property of the first `block` of the event: `event.blocks.first.rsvp_cap`.)

Calculating waitlists is done in two locations:

- Event info pages: https://hkn.eecs.berkeley.edu/events/1448
- Event rsvp pages: https://hkn.eecs.berkeley.edu/events/1448/rsvps

The following still have to be implemented:
- [x] Actually allowing rsvps beyond the cap to be `create`d. ([rsvps_controller.rb#69](https://github.com/compserv/hkn-rails/blob/22106c14f23c1f2419b865fe2ba2678691f32199/app/controllers/rsvps_controller.rb#L69))
- [x] Viewing personal waitlist spots in the "My RSVPs" page (https://hkn.eecs.berkeley.edu/events/rsvps). This will take O(nk) time for n people over k rsvp'd events, but this is usually small.
- [x] Showing waitlist sizes on the event pages

I think it would be wise not to display waitlist numbers for other people publicly (perhaps to internal officers only, on the event rsvp table). 