### PR TITLE
Expand shortlink edit permissions to all officers

### DIFF
--- a/app/models/shortlink.rb
+++ b/app/models/shortlink.rb
@@ -19,6 +19,6 @@ class Shortlink < ActiveRecord::Base
   belongs_to :person
 
   def own?(current_user, auth)
-    person == current_user || auth['superuser']
+    person == current_user || auth['officers'] || auth['superuser']
   end
 end


### PR DESCRIPTION
Oft-requested feature.

I'm not sure this is the right permission model we want; this is obviously temporary until the new site has shortlinks, but what kind of edit permissions over shortlinks should we grant to officers?

Some options:
- All officers can edit (implemented in PR)
- Creator's committee can edit (what is creator's 'committee' if they are on multiple as cmember?)
- Creator + execs can edit (loads execs with committee work)
- Manually select edit permissions: committee / all (default to creator's committee?)
- Creator only, but can hand off ownership