### PR TITLE
Wrap displayed shortlink URLs so that buttons are still shown

### DIFF
--- a/app/assets/stylesheets/main.css.erb
+++ b/app/assets/stylesheets/main.css.erb
@@ -91,6 +91,7 @@ tr.even { background-color: #f9f9f9; }
 tr.odd  { background-color: #fff; }
 
 td { border: 1px dashed #ddd; padding: 2px 4px; }
+td.break-word { word-break: break-word; }
 .infodiv { width: 300px; text-align: left; }
 .two-column { width: 45%; float: left; }
 .right-column { float: right; }

--- a/app/views/shortlinks/index.html.haml
+++ b/app/views/shortlinks/index.html.haml
@@ -17,7 +17,7 @@
     - @shortlinks.each do |shortlink|
       %tr
         %td= shortlink.in_url
-        %td= shortlink.out_url
+        %td{class: "break-word"}= shortlink.out_url
         %td= link_to shortlink.person.full_name, shortlink.person
         %td= link_to 'Edit', edit_shortlink_path(shortlink) if shortlink.own?(@current_user, @auth)
         %td= link_to 'Destroy', shortlink, method: :delete, data: { confirm: 'Are you sure?' } if shortlink.own?(@current_user, @auth)


### PR DESCRIPTION
Tested locally to make sure I didn't mess up the HAML or something lol:
![very-long-shortlink-test](https://user-images.githubusercontent.com/1523594/92444905-657ff980-f168-11ea-81f9-b4a9365d80dd.png)