### PR TITLE
ohqueue links replacing zoom link & home page tutoring table change properly

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,8 +7,11 @@ class HomeController < ApplicationController
     prop = Property.get_or_create
     @tutoring_enabled = prop.tutoring_enabled
     @hours = prop.tutoring_start .. prop.tutoring_end
-    time = Time.now
-    time = time.tomorrow if time.hour > prop.tutoring_end
+    time = Time.now.in_time_zone('Pacific Time (US & Canada)')
+
+    applyTempFix = true
+    time = time.tomorrow if time.hour > (prop.tutoring_end + ((applyTempFix) ? 5 : 0))
+    
     time = time.next_week unless (1..5).include? time.wday
     @day = time.wday
     @tutor_title = "#{time.strftime("%A")}'s Tutoring Schedule"

--- a/app/views/tutor/schedule.html.erb
+++ b/app/views/tutor/schedule.html.erb
@@ -3,7 +3,7 @@
 <div style="float: left; width: 80%; text-align: center; margin-bottom: 30px;">
 
 <p><strong>Notice:</strong> Due to course policy, HKN tutors cannot help with projects.</p>
-<a href="https://hkn.mu/tutor-zoom">Head to hkn.mu/tutor-zoom!</a>
+<a href="http://hkn.mu/ohqueue">Head to hkn.mu/ohqueue!</a>
 
 <% tutors = [] %>
 


### PR DESCRIPTION
Note that the time on the system (or at least my system) was on UTC (+0)

Using a local fix (this won't make it system-wide I hope), I made it run on PST/PDT automatically via a function call on the Time.now, setting it to PT