### PR TITLE
Hotfix: 404 error if survey with deleted iship is requested

### DIFF
--- a/app/controllers/coursesurveys_controller.rb
+++ b/app/controllers/coursesurveys_controller.rb
@@ -398,6 +398,10 @@ class CoursesurveysController < ApplicationController
   def rating
     @answer = SurveyAnswer.find(params[:id])
     return redirect_to coursesurveys_path, notice: "Error: Couldn't find that rating." unless @answer
+    # TODO: survey answers not deleted if instructorship link broken
+    if @answer.instructor.nil?
+      self.render_404
+    end
     @instructor = @answer.instructor
     if @instructor.private && !@privileged
       return redirect_to(coursesurveys_path, notice: "You are not authorized to view that page.")

--- a/app/models/survey_answer.rb
+++ b/app/models/survey_answer.rb
@@ -15,7 +15,7 @@
 class SurveyAnswer < ActiveRecord::Base
   include CoursesurveysHelper
 
-  belongs_to :instructorship
+  belongs_to :instructorship, dependent: :destroy
   belongs_to :survey_question
 
   has_one :instructor, through: :instructorship


### PR DESCRIPTION
This hotfixes (read: covers up) the errors resulting from requesting a broken SurveyAnswer:

> A NoMethodError occurred in coursesurveys#rating:
> 
>   undefined method `private' for nil:NilClass
>   app/controllers/coursesurveys_controller.rb:402:in `rating'

Specifically this is the result of trying to access a null `instructor` object linked to a particular SurveyAnswer:

```rb
if @instructor.private && !@privileged
  ...
```

The root cause of this appears to be incorrect deletion behavior when a particular `Instructorship` is deleted. Specifically, Instructorship deletions (I'm guessing, requested by professors with spurious course survey data) do not cause cascading  SurveyAnswer deletion. This is fixed in `survey_answer.rb` by specifying `:destroy` as the `dependent:` deletion behavior.

I'm not sure what to do with the existing broken objects. For now, I'm 404ing on the page instead of 500 erroring. I have a quick script to delete all of the broken objects but I'm hesitant to delete survey data, even if the instructorship is deleted.

This is, however, completely a guess. @jvperrin I'd appreciate a spot-check if is the right place to specify the destroy behavior.