### PR TITLE
OpSec Role in Committee and Exec

### DIFF
--- a/app/models/committeeship.rb
+++ b/app/models/committeeship.rb
@@ -12,10 +12,10 @@
 #
 
 class Committeeship < ActiveRecord::Base
-  @Committees = %w(pres vp rsec treas csec deprel act alumrel bridge compserv decal indrel serv studrel tutoring pub examfiles ejc prodev)	#This generates a constant which is an array of possible committees.
+  @Committees = %w(pres vp rsec treas csec deprel act alumrel opsec bridge compserv decal indrel serv studrel tutoring pub examfiles ejc prodev)	#This generates a constant which is an array of possible committees.
   Semester = /\A\d{4}[0-4]\z/                  # A regex which validates the semester
   Positions = %w(officer assistant cmember candidate)  # A list of possible positions
-  Execs = %w(pres vp rsec csec treas deprel alumrel) # Executive positions
+  Execs = %w(pres vp rsec csec treas deprel alumrel opsec) # Executive positions
   NonExecs = @Committees - Execs
 
   validates_presence_of :person_id
@@ -79,6 +79,7 @@ class Committeeship < ActiveRecord::Base
       "vp"       => "Vice President",
       "rsec"     => "Recording Secretary",
       "csec"     => "Corresponding Secretary",
+      "opsec"    => "Operations Secretary",
       "treas"    => "Treasurer",
       "deprel"   => "Department Relations",
       "act"      => "Activities",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,6 +38,7 @@ def initialize_groups
     {"name"=>"vp",        "description"=>"Vice President"},
     {"name"=>"rsec",      "description"=>"Recording Secretary"},
     {"name"=>"csec",      "description"=>"Corresponding Secretary"},
+    {"name"=>"opsec",     "description"=>"Operations Secretary"},
     {"name"=>"treas",     "description"=>"Treasury"},
     {"name"=>"deprel",    "description"=>"Department Relations"},
     {"name"=>"serv",      "description"=>"Service"},


### PR DESCRIPTION
Steps to setup / test:
1. Open the Rails Console (non-sandbox, unless you want to practice / double check) and type or paste: `Group.new(name:"opsec", description:"The opsec committee", committee:true).save()`
    * This creates a New Group entry, then save it immediately
2. Go to RSec Admin in the localhost, and add someone to the OpSec Committee and Elect them, then commit them via the "Commit" or the "Red Button"
3. The Operations Secretary role will show up on the Officer page
