### PR TITLE
Improper Department Format Fix

### DIFF
--- a/app/controllers/exams_controller.rb
+++ b/app/controllers/exams_controller.rb
@@ -159,6 +159,10 @@ class ExamsController < ApplicationController
   def department
     @dept_name, @courses = Exam.get_dept_name_courses_tuples(params[:dept_abbr])
 
+    if (@dept_name.length() == 0) && ( @courses.length() == 0) then
+      self.render_404
+    end
+    
     respond_to do |format|
       format.html # index.html.erb
       format.xml  { render xml: @exams }

--- a/app/models/exam.rb
+++ b/app/models/exam.rb
@@ -54,6 +54,9 @@ class Exam < ActiveRecord::Base
 
   def Exam.get_dept_name_courses_tuples(dept_abbr)
     dept = Department.find_by_nice_abbr(dept_abbr)
+    if dept.nil?
+      return ["", []]
+    end
     dept_name = dept.name
     courses = Course.where(department_id: dept.id)
                     .includes(:exams)


### PR DESCRIPTION
When the department name is not correct or none exists, the website gives an error message

However, this fix provides a blank value for both

When in the exams part of the website though, it goes to 404, usually because people enter URLs like: `exams/course/cs170`, but the correct format is `exams/course/CS/170` so that the website can parse it correctly