### PR TITLE
Events iCal - Remove HTML format, since never used

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -425,7 +425,6 @@ class EventsController < ApplicationController
     # which usually lies in the previous month
 
     respond_to do |format|
-      format.html { render :hkn, layout: false }
       format.ics {
         render text: generate_ical_text(@events)
       }
@@ -439,8 +438,7 @@ class EventsController < ApplicationController
   def ical_single_event
     @event = [Event.with_permission(@current_user).find(params[:id])]
     respond_to do |format|
-        format.html { render :hkn, layout: false }
-        format.ics { render text: generate_ical_text(@event) }
+      format.ics { render text: generate_ical_text(@event) }
     end
   end
 


### PR DESCRIPTION
This should 404 since format not found
Tested on production website using another format like "csv" and it 404s