### PR TITLE
Registration form to only allow for HKN Members using hkn.eecs domain

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -56,14 +56,15 @@ class Person < ActiveRecord::Base
     module Regex
       Https = /\A(https:\/\/|\/).*\z/i
       BerkeleyEmail = /@berkeley\.edu\z/i
+      HKNEmail = /@hkn\.eecs\.berkeley\.edu\z/i
     end
   end
 
   validates_format_of :picture,    with: Validation::Regex::Https,
                                    allow_nil: true,
                                    allow_blank: true
-  # validates_format_of :email,      with: Validation::Regex::BerkeleyEmail,
-  #                                  message: 'must be an @berkeley.edu email'
+  validates_format_of :email,      with: Validation::Regex::HKNEmail,
+                                   message: 'must be an HKN Gmail using the hkn.eecs domain'
 
   # Username, password, and email validation is done by AuthLogic
 

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -23,7 +23,7 @@
     <%= f.text_field :username %>
   </div>
   <div class="field">
-    <%= f.label :email %>
+    <%= f.label :email, "HKN Gmail (hkn.eecs only)" %>
     <%= f.text_field :email %>
   </div>
   <div class="field">

--- a/app/views/people/new.html.erb
+++ b/app/views/people/new.html.erb
@@ -1,5 +1,4 @@
-<h1>Account Registration</h1>
-<p>*Please only register if you are a HKN candidate/member.
-   Otherwise, send us an email with your reason for
-   registration.</p>
+<h1>MEMBER ONLY Account Registration</h1>
+<p><strong>*Please only register if you are a HKN member. Site no longer used for candidates (please use dev-hkn).</strong>
+   Otherwise, send us an email with your reason for registration.</p>
 <%= render 'form' %>

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -52,7 +52,7 @@ describe Person, "when created with blank parameters" do
   it "should require an email of correct length" do
     @person.should_not be_valid
     #@person.errors[:email].should include("is too short (minimum is 6 characters)")
-    @person.errors[:email].should include("should look like an email address.")
+    @person.errors[:email].should include("should look like an HKN email address.")
   end
 
   it "should require a username of correct length" do
@@ -90,7 +90,7 @@ describe Person do
   it "should require an email to be correctly formatted" do
     person = Person.create(@good_opts.merge(email: "no_at_sign_and_no_domain"))
     person.should_not be_valid
-    person.errors[:email].should include("should look like an email address.")
+    person.errors[:email].should include("should look like an HKN email address.")
   end
 
   it "should require the password to be at least 8 characters long" do


### PR DESCRIPTION
As in the title, because people don't know how to read instructions on Slack or Notion

Also with other messaging to suggest member only Registration (ok for now due to soon depreciation of this site for dev-hkn site)

It also makes it a strict requirement during Registration

Testing completed by filling out the Registration form on localhost, with the expectation that at a minimum if all else is good the Captcha should only fail

Fails on non-hkn.eecs domain emails with the proper message
![image](https://user-images.githubusercontent.com/29664484/190830018-c034cbcb-4681-49cd-8863-6ad7b2573d74.png)
