### PR TITLE
Remove general validation, HKN Gmail validate on Register only

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -63,8 +63,8 @@ class Person < ActiveRecord::Base
   validates_format_of :picture,    with: Validation::Regex::Https,
                                    allow_nil: true,
                                    allow_blank: true
-  validates_format_of :email,      with: Validation::Regex::HKNEmail,
-                                   message: 'must be an HKN Gmail using the hkn.eecs domain'
+  # validates_format_of :email,      with: Validation::Regex::HKNEmail,
+  #                                  message: 'must be an HKN Gmail using the hkn.eecs domain'
 
   # Username, password, and email validation is done by AuthLogic
 


### PR DESCRIPTION
Error with someone forgetting their password, but the database has people with non-HKN in the past
This fixes that to allow for Forget Password on any account, only during registration HKN Gmails are allowed