### PR TITLE
changing valid hours for slots

### DIFF
--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -28,7 +28,7 @@ class Slot < ActiveRecord::Base
   end
 
   module Hour
-    Valid = (11 .. 16)
+    Valid = (11 .. 17)
   end
 
   ROOMS = { cory: Room::Cory, soda: Room::Soda, prodevcory: Room::ProDevCory}


### PR DESCRIPTION
Change slot valid hours from 11am-5pm to 11am-6pm to allow a prodev hour from 5-6pm
Currently the Slot model does not allow for the creation of a 5-6pm slot, even if you go into the admin panel and make tutoring hours from 11-6