### PR TITLE
Fixes for incorrect course survey displays

### DIFF
--- a/app/views/coursesurveys/instructor.html.haml
+++ b/app/views/coursesurveys/instructor.html.haml
@@ -188,7 +188,12 @@
                     Courses (#{courses.values.collect{|v|v[:eff].count}.sum})
                 - [:eff,:ww].each do |s|
                   - next if klasstype == :tad_klasses && s == :ww
-                  - numz = courses.values.collect{|v|v[s]}.flatten
+                  - numz = nil
+                  - if klasstype == :tad_klasses 
+                  - numz = courses.values.collect{|v|v[s] * 5.0 / v[:eff_max]}.flatten
+                  - else 
+                  - numz = s == :eff ? courses.values.collect{|v|v[s] * 7.0 / v[:eff_max]}.flatten : courses.values.collect{|v|v[s] * 7.0 / v[:ww_max]}.flatten
+                  - end
                   - if s != :eff || !@instructor.private || @privileged
                     %td= rating_and_bar(numz.avg, courses.values.drop_while{|x|x.nil?}.collect{|x|x["#{s}_max".to_sym]}.compact.first || 1) unless courses.empty? || !numz.any?
                   - else


### PR DESCRIPTION
Already done by modifying database: created new surveyQuestions with a max score of 7 and mapped existing answers from Fall 2022 and later to the newly created questions. There should no longer be any tas (or profs) with scores like 5.8/5, they should all be out of 7 (for fall 2022 and later). 
Note that this only created questions for existing answers with an incorrect max score -- if the department suddenly releases a new question with the same text as an old question (but that should be out of 7), there is no corresponding question created for it.

In this commit: 
1. Updated course survey upload helper to take the most recently created survey question (aka the newly made one with a max score of 7)

2. Normalized instructor effectiveness and worthwhileness scores before averaging, which prevents issues like having 5.1/5 average because they were in semesters both before and after fall 22
