### PR TITLE
Add 404 logic for 0 or negative pages

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -57,6 +57,9 @@ class EventsController < ApplicationController
                      .where.not(event_types: {name: ["Exam", "Review Session"]})
 
     if (page_no = Integer(params[:page] || 1) rescue nil)
+      if (page_no < 1)
+        self.render_404
+      end
       @events = @events.page(page_no).per_page(per_page)
     else
       self.render_404


### PR DESCRIPTION
Tested for other similar errors: Over max pages is purely blank

Apparently negative or 0 number pages are not handled properly causing the following error:

A RangeError occurred in events#index:

  invalid page: -1839
  app/controllers/events_controller.rb:60:in `index'

This simply fixes that with a 404 error that is on purpose, but does not pop up an error and thus send to CompServ

Tested and developed (and patched temporarily) on Production server (don't do this often :P)