### PR TITLE
Update URL Rerouting to encode brackets in URI Encoding

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -398,9 +398,9 @@ HknRails::Application.routes.draw do
   resources :shortlinks, except: :show
 
   # Redirect to prot's subdomain, keeping the path and any extensions in the request
-  match '/mediawiki(/*path)', via: :all, to: redirect { |params, _| URI.encode("https://prot-hkn.eecs.berkeley.edu/w/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}") }
-  match '/prot(/*path)',      via: :all, to: redirect { |params, _| URI.encode("https://prot-hkn.eecs.berkeley.edu/wiki/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}") }
-  match '/prot2(/*path)',     via: :all, to: redirect { |params, _| URI.encode("https://prot-hkn.eecs.berkeley.edu/w/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}") }
+  match '/mediawiki(/*path)', via: :all, to: redirect { |params, _| URI.encode("https://prot-hkn.eecs.berkeley.edu/w/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}", "[]") }
+  match '/prot(/*path)',      via: :all, to: redirect { |params, _| URI.encode("https://prot-hkn.eecs.berkeley.edu/wiki/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}", "[]") }
+  match '/prot2(/*path)',     via: :all, to: redirect { |params, _| URI.encode("https://prot-hkn.eecs.berkeley.edu/w/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}", "[]") }
 
   # Redirect some alumni sites that were discontinued but requested redirects to
   # prevent any old links breaking
@@ -410,8 +410,8 @@ HknRails::Application.routes.draw do
   match '/~calbear/research.html', via: :all, to: redirect { "http://research.mbbaer.com/" }
   match '/~calbear/research/', via: :all, to: redirect { "http://mbbaer.com/" }
 
-  match '/~chenm(/*path)', via: :all, to: redirect { |params, _| URI.encode("https://www.ocf.berkeley.edu/~morganjchen/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}") }
-  match '/~dyoo(/*path)', via: :all, to: redirect { |params, _| URI.encode("http://www.hashcollision.org/hkn/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}") }
+  match '/~chenm(/*path)', via: :all, to: redirect { |params, _| URI.encode("https://www.ocf.berkeley.edu/~morganjchen/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}", "[]") }
+  match '/~dyoo(/*path)', via: :all, to: redirect { |params, _| URI.encode("http://www.hashcollision.org/hkn/#{ params[:path] }#{ '.' + params[:format] if params[:format].present?}", "[]") }
 
   # This section must remain at the bottom of the routes, since they are
   # catch-all routes to enable arbitrary hierarchy and placement of static pages


### PR DESCRIPTION
Fixes the common error of bracket encoding ignored leading to Bad URI redirect errors, this uses the extra parameters that tells Rails to encode the brackets
https://stackoverflow.com/questions/10814021/ruby-uriinvalidurierror-bad-uriis-not-uri-besides-encoding/10835810

Sample Error fixed:

An URI::InvalidURIError occurred in #:

  bad URI(is not URI?): [http://www.hashcollision.org/hkn/python/ahocorasick/[/url]](http://www.hashcollision.org/hkn/python/ahocorasick/%5B/url%5D)



\-------------------------------
Request:
\-------------------------------

  \* URL        : https://hkn.eecs.berkeley.edu/~dyoo/python/ahocorasick/%5B/url%5D
  \* HTTP Method: GET
 