### PR TITLE
RSec Admin Nomination Page - "New Officer" blank error check + Return properly after redirect

### DIFF
--- a/app/controllers/admin/rsec_controller.rb
+++ b/app/controllers/admin/rsec_controller.rb
@@ -50,14 +50,17 @@ class Admin::RsecController < Admin::AdminController
   #
   def add_elected
     if params[:position] == ""
-      return redirect_to admin_rsec_elections_path, notice: "Failed to elect for selected position, since no position was selected"
+      redirect_to admin_rsec_elections_path, notice: "Failed to elect for selected position, since no position was selected"
+      return
     end
     if params[:person_id] == ""
-      return redirect_to admin_rsec_elections_path, notice: "Failed to elect for \"#{params[:position]}\" because no one was selected"
+      redirect_to admin_rsec_elections_path, notice: "Failed to elect for \"#{params[:position]}\" because no one was selected"
+      return
     end
     e = Election.new(person_id: params[:person_id].to_i, position: params[:position])
     unless e.valid? && e.save
-      return redirect_to admin_rsec_elections_path, notice: "Failed to elect: #{e.person} because #{e.errors.inspect}"
+      redirect_to admin_rsec_elections_path, notice: "Failed to elect: #{e.person} because #{e.errors.inspect}"
+      return
     end
     redirect_to with_anchor(admin_rsec_elections_path,e.position), notice: "Nominated #{e.position} officer #{e.person.full_name}"
   end # add_elected

--- a/app/controllers/admin/rsec_controller.rb
+++ b/app/controllers/admin/rsec_controller.rb
@@ -49,6 +49,12 @@ class Admin::RsecController < Admin::AdminController
   # for the POSITION.
   #
   def add_elected
+    if params[:position] == ""
+      return redirect_to admin_rsec_elections_path, notice: "Failed to elect for selected position, since no position was selected"
+    end
+    if params[:person_id] == ""
+      return redirect_to admin_rsec_elections_path, notice: "Failed to elect for \"#{params[:position]}\" because no one was selected"
+    end
     e = Election.new(person_id: params[:person_id].to_i, position: params[:position])
     unless e.valid? && e.save
       return redirect_to admin_rsec_elections_path, notice: "Failed to elect: #{e.person} because #{e.errors.inspect}"


### PR DESCRIPTION
https://stackoverflow.com/questions/1183506/make-blank-params-nil

Using Election.new is fine (as long as the other parameters are fine also) https://stackoverflow.com/questions/33637552/save-activerecord-object-without-commit-rails-4

The issue that made Nominations create a buggy entry was this: https://github.com/rails/rails/issues/26363
Code continued to keep running despite blank Person and Position params ("invalid" entries are not covered here, but a minor issue since only this page is running the function, and by UI limits the input available)
